### PR TITLE
Make Jekyll use upgraded version of pygments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'jekyll'
+gem 'jekyll', :github => 'jekyll/jekyll', :branch => 'pygments-upgrade'
 
 gem 'bourbon'
 gem 'sass'


### PR DESCRIPTION
Older pygmments doesn't work with ruby 2.4 because of a problem with yajl-ruby